### PR TITLE
fix: move usb lock to remoteWD

### DIFF
--- a/gwda.go
+++ b/gwda.go
@@ -46,7 +46,7 @@ func newRequest(method string, url string, rawBody []byte) (request *http.Reques
 
 var _mUSB sync.Mutex
 
-func executeHTTP(method string, rawURL string, rawBody []byte, usbHTTPClient ...*http.Client) (rawResp rawResponse, err error) {
+func executeHTTP(wd *remoteWD, method string, rawURL string, rawBody []byte, usbHTTPClient ...*http.Client) (rawResp rawResponse, err error) {
 	debugLog(fmt.Sprintf("--> %s %s\n%s", method, rawURL, rawBody))
 	var req *http.Request
 	if req, err = newRequest(method, rawURL, rawBody); err != nil {
@@ -56,8 +56,8 @@ func executeHTTP(method string, rawURL string, rawBody []byte, usbHTTPClient ...
 	tmpHTTPClient := HTTPClient
 	if len(usbHTTPClient) != 0 {
 		tmpHTTPClient = usbHTTPClient[0]
-		_mUSB.Lock()
-		defer _mUSB.Unlock()
+		wd.UsbLock.Lock()
+		defer wd.UsbLock.Unlock()
 	}
 
 	start := time.Now()


### PR DESCRIPTION
the global usb mutext will cause all gwda driver instance is blocked