### PR TITLE
fix: driver tap and healthy

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -506,7 +506,11 @@ func (wd *remoteWD) TapFloat(x, y float64) (err error) {
 		"x": x,
 		"y": y,
 	}
-	_, err = wd.executePost(data, "/session", wd.sessionId, "/wda/tap/0")
+	_, err = wd.executePost(data, "/session", wd.sessionId, "/wda/tap")
+	if err != nil {
+		_, err = wd.executePost(data, "/session", wd.sessionId, "/wda/tap/0")
+		return
+	}
 	return
 }
 
@@ -913,10 +917,7 @@ func (wd *remoteWD) IsWdaHealthy() (healthy bool, err error) {
 	if rawResp, err = wd.executeGet("/health"); err != nil {
 		return false, err
 	}
-	if string(rawResp) != "I-AM-ALIVE" {
-		return false, nil
-	}
-	return true, nil
+	return strings.Contains(string(rawResp), "I-AM-ALIVE"), nil
 }
 
 func (wd *remoteWD) WdaShutdown() (err error) {


### PR DESCRIPTION
## 适配最新版本的 WDA

1. 点击指定位置使用新 URL 并兼容旧版本  #22
https://github.com/appium/WebDriverAgent/blob/master/CHANGELOG.md#600-2024-01-31

2. 健康检查目前返回是这样的，修改了判断方式
`<!DOCTYPE html><html><title>Health Check</title><body><p>I-AM-ALIVE</p></body></html>`